### PR TITLE
Add WebRTC voice chat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,15 @@
-
 ## Description
 
-A sample task for the [Tasks Framework](https://content.luanti.org/packages/AntumDeluge/tasks/) mod
-for [Luanti (Minetest)](https://luanti.org/).
+WebRTC-based voice chat example for [Luanti](https://luanti.org/).
 
-The task is completed by simply walking 50 nodes. Task is reset & initialized at every player login.
+The mod provides a `/voice` command that requests a session link from a
+signaling server and sends it to the player. Opening the link in a browser
+joins the voice chat room with a WebRTC client.
 
+Set the `voicechat_signaling_url` setting in `minetest.conf` to point to your
+signaling server.
 
 ## Licensing
 
 - Code: [MIT](LICENSE.txt)
-- Media: See [Media Sources](#Media_Sources)
 
-
-## Media Sources
-
-- sample_task_fanfare: by joepayne (CC0) https://freesound.org/s/413201/
-
-
-## Instructions
-
-Simply walk around. Once you have walked 50 nodes there will be a message & audio notification that
-the task has been completed. To reset exit game & reconnect.

--- a/init.lua
+++ b/init.lua
@@ -1,89 +1,49 @@
+-- Simple WebRTC voice chat example for Luanti
 
-local task_id = "step_50_nodes"
-local task_def = {
-	title = "Walk 50 Nodes",
-	description = "Just walk around.",
-	meta = {
-		req_steps = 50
-	},
+local http = minetest.request_http_api()
+local signaling_url = minetest.settings:get("voicechat_signaling_url") or "http://localhost:8080"
 
-	is_complete = function(self, player)
-		-- task is "complete" if player walked the number of nodes designated in `TaskDef.meta.req_steps`
-		return (tonumber(tasks.get_player_state(player, self.id, 1)) or 0) >= self.meta.req_steps
-	end,
+local function show_link(player, link)
+    local name = player:get_player_name()
+    minetest.chat_send_player(name, "[voicechat] Open this link in a browser to join: " .. link)
+end
 
-	on_complete = function(self, player)
-		-- send message & play sound to notify player task complete
-		core.chat_send_player(player:get_player_name(), "Completed task: \"" .. self.title .. "\"")
-		core.sound_play({name="sample_task_fanfare"}, {to_player=player:get_player_name()})
-	end,
+local function start_voice_chat(player)
+    if not http then
+        minetest.chat_send_player(player:get_player_name(), "[voicechat] HTTP API not available")
+        return
+    end
 
-	get_log = function(self, player)
-		local desc = {}
+    local name = player:get_player_name()
+    http.fetch({
+        url = signaling_url .. "/session?name=" .. minetest.urlencode_component(name),
+        method = "GET"
+    }, function(result)
+        if result.succeeded then
+            local data = minetest.parse_json(result.data)
+            if data and data.url then
+                show_link(player, data.url)
+            else
+                minetest.chat_send_player(name, "[voicechat] Invalid response from signaling server")
+            end
+        else
+            minetest.chat_send_player(name, "[voicechat] Failed to contact signaling server")
+        end
+    end)
+end
 
-		if self:is_complete(player) then
-			table.insert(desc, "I have completed the task.")
-		else
-			table.insert(desc, "I have not yet walked far enough.")
-		end
-		-- index 1 represents number of steps player has taken since task began
-		local steps = tonumber(tasks.get_player_state(player, self.id, 1)) or 0
-		table.insert(desc, "I have taken " .. steps .. " out of " .. self.meta.req_steps .. " steps.")
-
-		return desc
-	end,
-
-	logic = function(self, dtime, player)
-		local pos = player:getpos()
-		if pos == nil then
-			core.log("warning", "Could not determine position of player " .. player:get_player_name())
-			return
-		end
-		-- Note: movement on Z axis doesn't count
-		pos = {x=math.floor(pos.x), y=math.floor(pos.y)}
-		-- index 2 represents player's position at previous call
-		local old_pos = core.deserialize(tasks.get_player_state(player, self.id, 2)) or pos
-		local steps_taken = math.abs(pos.x - old_pos.x) + math.abs(pos.y - old_pos.y)
-		-- FIXME: compensate for teleporting
-		if steps_taken > 0 then
-			-- index 1 represents number of steps player has taken since task began
-			local total_steps = (tonumber(tasks.get_player_state(player, self.id, 1)) or 0) + steps_taken
-			if total_steps > self.meta.req_steps then
-				total_steps = self.meta.req_steps
-			end
-			-- set new position first as setting steps count may trigger `TaskDef:on_complete`
-			tasks.set_player_state(player, self.id, 2, core.serialize(pos))
-			tasks.set_player_state(player, self.id, 1, total_steps)
-		end
-	end
-}
-
-tasks.register(task_id, task_def)
-
-core.register_on_joinplayer(function(player, last_login)
-	local pos = player:getpos()
-	pos = {x=math.floor(pos.x), y=math.floor(pos.y)}
-	-- task initialization triggered by login (reset every login)
-	tasks.set_player_state(player, task_id, "0;" .. core.serialize(pos))
+minetest.register_on_joinplayer(function(player)
+    minetest.chat_send_player(player:get_player_name(), "Use /voice to start a WebRTC call.")
 end)
 
-core.register_on_leaveplayer(function(player, timed_out)
-	-- clean up player meta since we don't want sample task data to persist
-	tasks.set_player_state(player, task_id)
-	if tasks.player_has(player, task_id) then
-		core.log("warning", "Failed to clean up sample task with ID \"" .. task_id .. "\" for player "
-				.. player:get_player_name())
-	end
-end)
-
--- chat command to check task state for current player
-core.register_chatcommand("sample_task", {
-	params = "",
-	description = "Print state string of sample task for current player.",
-	privs = {},
-	func = function(name, param)
-		local player = core.get_player_by_name(name)
-		local state = tasks.get_player_state(player, task_id)
-		core.chat_send_player(name, "Sample task state: " .. state)
-	end
+minetest.register_chatcommand("voice", {
+    description = "Start a WebRTC voice chat session",
+    privs = {},
+    func = function(name)
+        local player = minetest.get_player_by_name(name)
+        if player then
+            start_voice_chat(player)
+        end
+    end
 })
+

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,3 @@
-name = sample_task
-description = Sample task to walk 50 nodes for Tasks Framework mod.
+name = voice_chat
+description = Simple WebRTC voice chat example.
 author = AntumDeluge
-depends = tasks


### PR DESCRIPTION
## Summary
- replace sample task logic with a WebRTC-based voice chat example
- expose `/voice` command that retrieves a session URL from a signaling server
- add documentation for configuring the signaling server

## Testing
- `luac -p init.lua`

------
https://chatgpt.com/codex/tasks/task_e_689956d22c5083268da76eea0760e999